### PR TITLE
Default to a VARIABLE weighting policy for averaging across blocks.

### DIFF
--- a/include/scran/differential_analysis/PairwiseEffects.hpp
+++ b/include/scran/differential_analysis/PairwiseEffects.hpp
@@ -125,7 +125,7 @@ public:
         /**
          * See `set_block_weight_policy()` for more details.
          */
-        static constexpr WeightPolicy block_weight_policy = WeightPolicy::NONE;
+        static constexpr WeightPolicy block_weight_policy = WeightPolicy::VARIABLE;
 
         /**
          * See `set_variable_block_weight_parameters()` for more details.

--- a/include/scran/differential_analysis/ScoreMarkers.hpp
+++ b/include/scran/differential_analysis/ScoreMarkers.hpp
@@ -280,7 +280,7 @@ public:
         /**
          * See `set_block_weight_policy()` for more details.
          */
-        static constexpr WeightPolicy block_weight_policy = WeightPolicy::NONE;
+        static constexpr WeightPolicy block_weight_policy = WeightPolicy::VARIABLE;
 
         /**
          * See `set_variable_block_weight_parameters()` for more details.

--- a/include/scran/dimensionality_reduction/MultiBatchPca.hpp
+++ b/include/scran/dimensionality_reduction/MultiBatchPca.hpp
@@ -70,7 +70,7 @@ public:
         /**
          * See `set_block_weight_policy()` for more details.
          */
-        static constexpr WeightPolicy block_weight_policy = WeightPolicy::EQUAL;
+        static constexpr WeightPolicy block_weight_policy = WeightPolicy::VARIABLE;
 
         /**
          * See `set_variable_block_weight_parameters()` for more details.

--- a/include/scran/dimensionality_reduction/ResidualPca.hpp
+++ b/include/scran/dimensionality_reduction/ResidualPca.hpp
@@ -72,7 +72,7 @@ public:
         /**
          * See `set_block_weight_policy()` for more details.
          */
-        static constexpr WeightPolicy block_weight_policy = WeightPolicy::NONE;
+        static constexpr WeightPolicy block_weight_policy = WeightPolicy::VARIABLE;
 
         /**
          * See `set_variable_block_weight_parameters()` for more details.

--- a/include/scran/feature_set_enrichment/ScoreFeatureSet.hpp
+++ b/include/scran/feature_set_enrichment/ScoreFeatureSet.hpp
@@ -47,7 +47,7 @@ public:
         /**
          * See `set_block_weight_policy()` for more details.
          */
-        static constexpr WeightPolicy block_weight_policy = WeightPolicy::EQUAL;
+        static constexpr WeightPolicy block_weight_policy = WeightPolicy::VARIABLE;
 
         /**
          * See `set_num_threads()` for more details.

--- a/tests/src/differential_analysis/PairwiseEffects.cpp
+++ b/tests/src/differential_analysis/PairwiseEffects.cpp
@@ -74,6 +74,9 @@ TEST_P(PairwiseEffectsUnblockedTest, Reference) {
     auto nthreads = std::get<2>(param);
     chd.set_num_threads(nthreads);
 
+    // Avoid issues with small numerical differences when the weights are different.
+    chd.set_block_weight_policy(scran::WeightPolicy::NONE);
+
     auto res = chd.run(dense_row.get(), groupings.data());
     auto ref = simple_reference(dense_row.get(), groupings.data(), ngroups, threshold);
 

--- a/tests/src/differential_analysis/ScoreMarkers.cpp
+++ b/tests/src/differential_analysis/ScoreMarkers.cpp
@@ -98,6 +98,11 @@ TEST_P(ScoreMarkersTest, Basic) {
     scran::ScoreMarkers chd;
     chd.set_compute_auc(do_auc); // false, if we want to check the running implementations.
     chd.set_num_threads(nthreads);
+
+    // Avoid issues with numerical precision when the weights are different,
+    // even if they ultimately cancel out in the calculation.
+    chd.set_block_weight_policy(scran::WeightPolicy::NONE);
+
     auto res = chd.run(dense_row.get(), groupings.data());
 
     // Running some further checks on the effects.

--- a/tests/src/dimensionality_reduction/MultiBatchPca.cpp
+++ b/tests/src/dimensionality_reduction/MultiBatchPca.cpp
@@ -56,6 +56,7 @@ TEST_P(MultiBatchPcaBasicTest, WeightedOnly) {
 
     scran::MultiBatchPca runner;
     runner.set_scale(scale).set_rank(rank);
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
 
     auto block = generate_blocks(dense_row->ncol(), nblocks);
     auto ref = runner.run(dense_row.get(), block.data());
@@ -200,6 +201,7 @@ TEST_P(MultiBatchPcaBasicTest, WeightedResidual) {
     scran::MultiBatchPca runner;
     runner.set_scale(scale).set_rank(rank);
     runner.set_use_residuals(true);
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
 
     auto block = generate_blocks(dense_row->ncol(), nblocks);
     auto ref = runner.run(dense_row.get(), block.data());
@@ -279,6 +281,7 @@ TEST_P(MultiBatchPcaMoreTest, WeightedOnly_VersusSimple) {
 
     scran::MultiBatchPca runner;
     runner.set_scale(scale).set_rank(rank);
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
     auto res1 = runner.run(expanded.get(), block.data());
 
     // Checking that we get more-or-less the same results
@@ -323,7 +326,8 @@ TEST_P(MultiBatchPcaMoreTest, WeightedOnly_DuplicatedBlocks) {
     scran::MultiBatchPca runner;
     runner.set_scale(scale).set_rank(rank);
 
-    // By default, every batch is equally weighted.
+    // Checking what happens when every batch is equally weighted.
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
     {
         auto res2 = runner.run(com.get(), block2.data());
         res2.pcs.array() /= res2.pcs.norm();
@@ -404,6 +408,8 @@ TEST_P(MultiBatchPcaMoreTest, ResidualOnly_VersusReference) {
 
     scran::ResidualPca refrunner;
     refrunner.set_scale(scale).set_rank(rank);
+    refrunner.set_block_weight_policy(scran::WeightPolicy::NONE);
+
     auto ref = refrunner.run(dense_row.get(), block.data());
 
     expect_equal_vectors(res.variance_explained, ref.variance_explained);
@@ -422,6 +428,7 @@ TEST_P(MultiBatchPcaMoreTest, WeightedResidual_VersusReference) {
     scran::MultiBatchPca runner;
     runner.set_scale(scale).set_rank(rank);
     runner.set_use_residuals(true);
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
 
     auto res = runner.run(dense_row.get(), block.data());
 
@@ -462,7 +469,8 @@ TEST_P(MultiBatchPcaMoreTest, WeightedResidual_DuplicatedBlocks) {
     runner.set_scale(scale).set_rank(rank);
     runner.set_use_residuals(true);
 
-    // By default, it's all equally weighted.
+    // Checking what happens if they're all equally weighted.
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
     {
         auto res2 = runner.run(com.get(), block2.data());
         res2.pcs.array() /= res2.pcs.norm();
@@ -551,6 +559,7 @@ TEST_P(MultiBatchPcaMoreTest, SubsetTest) {
 
     scran::MultiBatchPca runner;
     runner.set_scale(scale).set_rank(rank);
+    runner.set_block_weight_policy(scran::WeightPolicy::EQUAL);
 
     auto block = generate_blocks(dense_row->ncol(), 3);
     auto out = runner.run(dense_row.get(), block.data(), subset.data());

--- a/tests/src/dimensionality_reduction/ResidualPca.cpp
+++ b/tests/src/dimensionality_reduction/ResidualPca.cpp
@@ -194,6 +194,7 @@ TEST_P(ResidualPcaBasicTest, BasicConsistency) {
 
     scran::ResidualPca runner;
     runner.set_scale(scale).set_rank(rank);
+    runner.set_block_weight_policy(scran::WeightPolicy::NONE);
     auto block = generate_blocks(dense_row->ncol(), nblocks);
     auto ref = runner.run(dense_row.get(), block.data());
 
@@ -330,6 +331,7 @@ TEST_P(ResidualPcaMoreTest, VersusSimple) {
 
     scran::ResidualPca runner;
     runner.set_scale(scale).set_rank(rank);
+    runner.set_block_weight_policy(scran::WeightPolicy::NONE);
     auto res1 = runner.run(dense_row.get(), block.data());
 
     if (nblocks == 1) {
@@ -466,6 +468,7 @@ TEST_P(ResidualPcaWeightedTest, VersusReference) {
 
     scran::ResidualPca runner;
     runner.set_scale(scale).set_rank(rank);
+    runner.set_block_weight_policy(scran::WeightPolicy::NONE);
     auto combined = tatami::make_DelayedBind<1>(components);
     auto ref = runner.run(combined.get(), blocking.data());
 


### PR DESCRIPTION
This provides a good balance between equalizing the contribution of each block and avoiding too much noise from small batches.